### PR TITLE
update create topic script

### DIFF
--- a/scripts/create-topic.sh
+++ b/scripts/create-topic.sh
@@ -1,6 +1,6 @@
 docker exec -it kafka /opt/bitnami/kafka/bin/kafka-topics.sh \
     --create \
-    --zookeeper zookeeper:2181 \
+    --bootstrap-server localhost:9092 \
     --replication-factor 1 \
     --partitions 1 \
     --topic test


### PR DESCRIPTION
Based on the comment from [Silviu Manea Hamzau](https://www.youtube.com/channel/UC_9YN1UpBRK_WLZqFWB-cdw) in the original youtube [video](https://www.youtube.com/watch?v=EiDLKECLcZw) : 

> Newer versions(2.2 and above) of Kafka no longer require ZooKeeper connection string ie --zookeeper localhost:2181 .... Instead, add Kafka Broker --bootstrap-server localhost:9092 connection string